### PR TITLE
[MA-178] Hotfix crash with Out Of Memory

### DIFF
--- a/url_driller/build.gradle
+++ b/url_driller/build.gradle
@@ -21,7 +21,7 @@ task projectInfo << {
     println " === ${project.group}:${project.name}:${project.version} - (${System.getenv("CIRCLE_BUILD_NUM")}) ==="
     println ""
 }
-version = "1.3.2"
+version = "1.3.3"
 group = "net.pubnative"
 def project_name = "url-driller"
 def version_name = version

--- a/url_driller/src/main/java/net/pubnative/URLDriller.java
+++ b/url_driller/src/main/java/net/pubnative/URLDriller.java
@@ -138,7 +138,6 @@ public class URLDriller {
             if (mUserAgent != null) {
                 conn.setRequestProperty("User-Agent", mUserAgent);
             }
-
             conn.setInstanceFollowRedirects(false);
             conn.connect();
             conn.setReadTimeout(5000);

--- a/url_driller/src/main/java/net/pubnative/URLDriller.java
+++ b/url_driller/src/main/java/net/pubnative/URLDriller.java
@@ -180,8 +180,8 @@ public class URLDriller {
         } catch (Exception exception) {
             Log.e(TAG, "Drilling error: " + exception);
             invokeFail(url, exception);
-        } catch (OutOfMemoryError error) {
-            Log.e(TAG, "Drilling OOM error: with URL = [" + url + "]", error);
+        } catch (Error error) {
+            Log.e(TAG, "Drilling error: with URL = [" + url + "]", error);
             invokeFinish(null);
         }
     }

--- a/url_driller/src/main/java/net/pubnative/URLDriller.java
+++ b/url_driller/src/main/java/net/pubnative/URLDriller.java
@@ -138,6 +138,7 @@ public class URLDriller {
             if (mUserAgent != null) {
                 conn.setRequestProperty("User-Agent", mUserAgent);
             }
+
             conn.setInstanceFollowRedirects(false);
             conn.connect();
             conn.setReadTimeout(5000);
@@ -180,6 +181,9 @@ public class URLDriller {
         } catch (Exception exception) {
             Log.e(TAG, "Drilling error: " + exception);
             invokeFail(url, exception);
+        } catch (OutOfMemoryError error) {
+            Log.e(TAG, "Drilling OOM error: with URL = [" + url + "]", error);
+            invokeFinish(null);
         }
     }
 


### PR DESCRIPTION
* Add new catch for the OutOfMemory for URLDriller
* Send `invokeFinish(null)`, if OOM detected 
* Bump library version