### PR TITLE
[MA-217] Fix Memory Leak in HttpUrlConnection

### DIFF
--- a/url_driller/build.gradle
+++ b/url_driller/build.gradle
@@ -21,7 +21,7 @@ task projectInfo << {
     println " === ${project.group}:${project.name}:${project.version} - (${System.getenv("CIRCLE_BUILD_NUM")}) ==="
     println ""
 }
-version = "1.3.3"
+version = "1.3.4"
 group = "net.pubnative"
 def project_name = "url-driller"
 def version_name = version

--- a/url_driller/src/main/java/net/pubnative/URLDriller.java
+++ b/url_driller/src/main/java/net/pubnative/URLDriller.java
@@ -179,6 +179,9 @@ public class URLDriller {
                 }
                 break;
             }
+
+            connection.getInputStream().close();
+            connection.getOutputStream().close();
         } catch (Exception exception) {
             Log.e(TAG, "Drilling error: " + exception);
             invokeFail(url, exception);

--- a/url_driller/src/main/java/net/pubnative/URLDriller.java
+++ b/url_driller/src/main/java/net/pubnative/URLDriller.java
@@ -132,16 +132,19 @@ public class URLDriller {
     protected void doDrill(String url, int counter) {
 
         Log.v(TAG, "doDrill: " + url);
+
+        HttpURLConnection connection = null;
+
         try {
             URL urlObj = new URL(url);
-            HttpURLConnection conn = (HttpURLConnection) urlObj.openConnection();
+            connection = (HttpURLConnection) urlObj.openConnection();
             if (mUserAgent != null) {
-                conn.setRequestProperty("User-Agent", mUserAgent);
+                connection.setRequestProperty("User-Agent", mUserAgent);
             }
-            conn.setInstanceFollowRedirects(false);
-            conn.connect();
-            conn.setReadTimeout(5000);
-            int status = conn.getResponseCode();
+            connection.setInstanceFollowRedirects(false);
+            connection.connect();
+            connection.setReadTimeout(5000);
+            int status = connection.getResponseCode();
             Log.v(TAG, " - Status: " + status);
             switch (status) {
                 case HttpURLConnection.HTTP_OK: {
@@ -152,7 +155,7 @@ public class URLDriller {
                 case HttpURLConnection.HTTP_MOVED_TEMP:
                 case HttpURLConnection.HTTP_MOVED_PERM:
                 case HttpURLConnection.HTTP_SEE_OTHER: {
-                    String newUrl = conn.getHeaderField("Location");
+                    String newUrl = connection.getHeaderField("Location");
                     Log.v(TAG, " - Redirecting: " + newUrl);
                     if (newUrl.startsWith("/")) {
                         String protocol = urlObj.getProtocol();
@@ -160,7 +163,6 @@ public class URLDriller {
                         newUrl = protocol + "://" + host + newUrl;
                     }
                     invokeRedirect(newUrl);
-                    conn.disconnect();
                     if (mDrillSize == 0) {
                         doDrill(newUrl);
                     } else if (mDrillSize > 0 && counter < mDrillSize) {
@@ -183,6 +185,10 @@ public class URLDriller {
         } catch (Error error) {
             Log.e(TAG, "Drilling error: with URL = [" + url + "]", error);
             invokeFinish(null);
+        } finally {
+            if (connection != null) {
+                connection.disconnect();
+            }
         }
     }
 


### PR DESCRIPTION
In Android, HttpUrlConnection has a very big problem with the resource allocation. Method `getResponseCode()` create a new InputStream inside and don't release it. For this, we should get the stream and close it manually. And also, we should close the connection after finish using it.